### PR TITLE
Add option to override faraday options

### DIFF
--- a/lib/webpagetest/connection.rb
+++ b/lib/webpagetest/connection.rb
@@ -3,19 +3,20 @@ module Webpagetest
   module Connection
 
     ENDPOINT = 'http://www.webpagetest.org/'
+    FARADAY_OPTIONS = {
+      request: :url_encoded,
+      response: :logger,
+      adapter: Faraday.default_adapter,
+    }
 
     def get_connection(options = nil)
-      options = Hashie::Mash.new( {
-        request: :url_encoded,
-        response: :logger,
-        adapter: Faraday.default_adapter,        
-      } ) if options.nil?
-      
+      options = Hashie::Mash.new(FARADAY_OPTIONS) if options.nil?
+
       url = options.url || ENDPOINT
 
       connection = Faraday.new(url: url) do |faraday|
         faraday.request  options.request
-        faraday.response options.response
+        faraday.response options.response unless options.response.nil?
         faraday.adapter  options.adapter
       end
     end


### PR DESCRIPTION
This allows you to redefine Webpagetest::Connection::FARADAY_OPTIONS to silence logging, by not adding `response: :logger`, i.e.

```
Webpagetest::Connection::FARADAY_OPTIONS = {
  request: :url_encoded,
  adapter: Faraday.default_adapter
}
```
