### PR TITLE
updated connection endpoint to use https

### DIFF
--- a/lib/webpagetest/connection.rb
+++ b/lib/webpagetest/connection.rb
@@ -2,7 +2,7 @@ module Webpagetest
   # Configures and performs connection requests
   module Connection
 
-    ENDPOINT = 'http://www.webpagetest.org/'
+    ENDPOINT = 'https://www.webpagetest.org/'
     FARADAY_OPTIONS = {
       request: :url_encoded,
       response: :logger,


### PR DESCRIPTION
webpagetest migrated to using ssl only so a http request would return a 301 status code, breaking the functionality of the gem.
